### PR TITLE
feat(entityDetails): accordion list starts opened

### DIFF
--- a/src/components/entity-detail/AccordionList.tsx
+++ b/src/components/entity-detail/AccordionList.tsx
@@ -1,5 +1,5 @@
 import { Theme, useTheme } from '@react-navigation/native'
-import React, { Key } from 'react'
+import React, { Key, useState } from 'react'
 import { StyleSheet, View } from 'react-native'
 import { Divider, List as ListComponent } from 'react-native-paper'
 import { List } from 'wollok-ts/dist/model'
@@ -8,14 +8,22 @@ type Props<Item> = {
 	title: string
 	items: Item[]
 	VisualItem: React.FC<{ item: Item }>
+	initialExpanded?: boolean
 }
 export const AccordionList = function <
 	Item extends { name: Key; parameters?: List<any> },
 >(props: Props<Item>) {
 	const reactNavigationTheme = useTheme()
 	const styles = getStyles(reactNavigationTheme)
+	const [expanded, setExpanded] = useState<boolean>(
+		props.initialExpanded || false,
+	)
+
 	return (
-		<ListComponent.Accordion title={props.title}>
+		<ListComponent.Accordion
+			title={`${props.title} (${props.items.length})`}
+			expanded={expanded}
+			onPress={() => switchExpanded()}>
 			{props.items.map(item => {
 				return (
 					<View key={`${item.name}${item.parameters?.length}`}>
@@ -26,6 +34,10 @@ export const AccordionList = function <
 			})}
 		</ListComponent.Accordion>
 	)
+
+	function switchExpanded() {
+		setExpanded(!expanded)
+	}
 }
 
 function getStyles(theme: Theme) {

--- a/src/pages/EntityDetails/EntityDetails.tsx
+++ b/src/pages/EntityDetails/EntityDetails.tsx
@@ -39,11 +39,13 @@ export const EntityDetails = function () {
 						title={wTranslate('entityDetails.attributes').toUpperCase()}
 						items={entity.members.filter(is('Field')) as Field[]}
 						VisualItem={AttributeItem}
+						initialExpanded={true}
 					/>
 					<AccordionList<Method>
 						title={wTranslate('entityDetails.methods').toUpperCase()}
 						items={entity.members.filter(is('Method')) as Method[]}
 						VisualItem={MethodItem}
+						initialExpanded={true}
 					/>
 				</ScrollView>
 			</List.Section>


### PR DESCRIPTION
Fix https://github.com/uqbar-project/wollok-mobile/issues/19

Iniciar listado de atributos y metodos abierto al entrar a EntityDetails.

Se hace uso de la propiedad expanded y onPress de Accordion para setear el valor inicial de apertura (o no) del componente y para ir switcheando su valor acorde a cuando se lo clickea.
Por deffault el valor inicial de expanded sera false, por lo cual arrancara cerrado, pero se le pueda pasar por props initialExpanded={true} para que el listado inicie abierto

Adicionalmente se cuenta la cantidad de items a mostrar en el Accordion y en el titulo del componente se muestra a continuación del title ingresado la cantidad de items presentes entre paréntesis.

![image](https://user-images.githubusercontent.com/48839912/152691198-db94a75a-949e-41d3-9668-bbe01f87c69a.png)
