### PR TITLE
Make CD run only on pushes to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           lane: 'deploy'
           subdirectory: 'android'
 
-      - name: Commit
+      - name: Commit version bump
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Deploy
 
 on:
   push:
-    tags:        
-      - 'v*'
+    branches:        
+      - 'main'
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,14 +63,22 @@ jobs:
           lane: 'deploy'
           subdirectory: 'android'
 
+      - name: Get node package version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@master
+
       - name: Commit version bump
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git add android/app/build.gradle
           git commit -m "chore: version update" --no-verify
-          git push https://$USERNAME:$REPO_KEY@github.com/uqbar-project/wollok-mobile.git
+          git tag $RELEASE_TAG
+          git remote add origin https://$USERNAME:$REPO_KEY@github.com/uqbar-project/wollok-mobile.git
+          git push
+          git push $RELEASE_TAG
         env:
           REPO_KEY: ${{secrets.PAT}}
           USERNAME: github-actions[bot]
+          RELEASE_TAG: v${{ steps.package-version.outputs.current-version}}
 

--- a/README.md
+++ b/README.md
@@ -57,3 +57,8 @@ yarn publish-release:android
 ```
 
 note: The keystore generation is a one time only process, after that you can reuse the already generated one.
+
+
+## Releases
+
+A release is triggered on **every** push to _main_. A tag will be created based on the _package.json_ version number, said version must be bumped **manually**.

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -22,11 +22,11 @@ platform :android do
 
     sh("yarn", "clean-android-assets")
 
-    last_tag = last_git_tag(pattern: "v*")
-
+    package = load_json(json_path: "../package.json")
+    
     android_set_version_name(
       gradle_file: "app/build.gradle",
-      version_name: last_tag
+      version_name: package["version"]
     )
 
     increment_version_code(

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -22,7 +22,7 @@ platform :android do
 
     sh("yarn", "clean-android-assets")
 
-    last_tag = last_git_tag()
+    last_tag = last_git_tag(pattern: "v*")
 
     android_set_version_name(
       gradle_file: "app/build.gradle",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wollokmobile",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"private": true,
 	"scripts": {
 		"android": "react-native run-android",


### PR DESCRIPTION
Closes #58 

El cambio en funcionalidad mas polemico que trae este PR es que ahora la version se va a traer del package.json en vez de la tag (no va a haber mas tags). Tal vez en el futuro haya que automatizar el bumpeo de versiones pero por ahora va a haber que hacerlo a mano.